### PR TITLE
前の入力文字数が次の問題に意図せず引き継がれている

### DIFF
--- a/components/CodeBlock/index.stories.tsx
+++ b/components/CodeBlock/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { CodeBlock } from "./index";
 
@@ -16,12 +16,22 @@ type Story = StoryObj<CodeBlockStory>;
 
 export const Default: Story = (args: CodeBlockStory) => {
   const [isFinish, setIsFinish] = useState(false);
+  const queryList = ["!cp []c", "!cp []c\n\t!cp []c"];
+  const [clearCounter, setClearCounter] = useState<number>(0);
+
+  useEffect(() => {
+    if (isFinish) {
+      setIsFinish(false);
+      setClearCounter(clearCounter + 1);
+    }
+  }, [isFinish]);
+
   return (
     <>
-      {isFinish ? (
+      {clearCounter === queryList.length ? (
         <p>finish</p>
       ) : (
-        <CodeBlock {...args} setIsFinish={setIsFinish} />
+        <CodeBlock query={queryList[clearCounter]} setIsFinish={setIsFinish} />
       )}
     </>
   );

--- a/components/CodeBlock/index.stories.tsx
+++ b/components/CodeBlock/index.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = (args: CodeBlockStory) => {
       {clearCounter === queryList.length ? (
         <p>finish</p>
       ) : (
-        <CodeBlock query={queryList[clearCounter]} setIsFinish={setIsFinish} />
+        <CodeBlock key={clearCounter} query={queryList[clearCounter]} setIsFinish={setIsFinish} />
       )}
     </>
   );

--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -88,6 +88,7 @@ export const CodeBlock = ({ query, setIsFinish }: Props) => {
     const newTotal = index.total + 1;
 
     if (newTotal === query.length) {
+      setIndex({ total: 0, row: 0, column: 0 });
       setIsFinish(true);
       return;
     }

--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -88,7 +88,6 @@ export const CodeBlock = ({ query, setIsFinish }: Props) => {
     const newTotal = index.total + 1;
 
     if (newTotal === query.length) {
-      setIndex({ total: 0, row: 0, column: 0 });
       setIsFinish(true);
       return;
     }


### PR DESCRIPTION
## 🔨 変更内容

- queryの文字全てを入力後、入力文字数を初期化してから親コンポーネントに返す
  - これにより、次の問題の初期の入力文字数が0となる

## 📸 スクリーンショット

https://github.com/nglcobdai/typing-game/assets/68684653/c8ba9f9a-95c7-452e-8ef6-d52a3b13b43c

## ✅ 解決するイシュー

- close #13 