### PR TITLE
タブキー入力で適切な無視ができていない

### DIFF
--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -71,7 +71,7 @@ export const CodeBlock = ({ query, setIsFinish }: Props) => {
   }, []);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    let keyPressed = event.key;
+    const keyPressed = event.key;
 
     switch (query[index.total]) {
       case "\n":

--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -92,7 +92,13 @@ export const CodeBlock = ({ query, setIsFinish }: Props) => {
       return;
     }
     if (newColumn === queryList[index.row].length + 1) {
-      setIndex({ total: newTotal, row: index.row + 1, column: 0 });
+      const newRow = index.row + 1;
+      if (query[newTotal] === "\t") {
+        // 改行後にタブがある場合、タブの分だけインデックスを進める
+        setIndex({ total: newTotal + 1, row: newRow, column: 1 });
+      } else {
+        setIndex({ total: newTotal, row: newRow, column: 0 });
+      }
     } else setIndex({ total: newTotal, row: index.row, column: newColumn });
   };
 

--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -30,7 +30,7 @@ export const CodeBlock = ({ query, setIsFinish }: Props) => {
   const queryList = query.split("\n");
 
   const replaceWhitespaceTab = (text: string) => {
-    return text.replace(/ /g, "\u00A0").replace(/\t/g, "\u00A0\u00A0");
+    return text.replace(/ /g, "\u00A0").replace(/\t/g, "\u23B5\u23B5");
   };
 
   const splitText = (i: number, text: string) => {


### PR DESCRIPTION
## 🔨 変更内容

- 改行後に`\t`がある場合には、その存在を無視する
- 明示的にタブの入力が不要であることを`⎵`の色が変わっていることで示す

## 📸 スクリーンショット


https://github.com/nglcobdai/typing-game/assets/68684653/80682ae8-7a9f-4454-a86c-2edc7437b68f



## ✅ 解決するイシュー

- close #14 

## 💡 補足

- タブの空白スペースのみを`⎵`で表現しているが、半角スペース1つの時も`⎵`で表現するべきかを悩んでいる
  - https://github.com/nglcobdai/typing-game/issues/18#issue-1773062318