### PR TITLE
CodeBlock内のmapでkeyを与える

### DIFF
--- a/components/CodeBlock/index.tsx
+++ b/components/CodeBlock/index.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 
-import { HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 
 type Props = {
   queryState: boolean;
@@ -108,7 +108,7 @@ export const CodeBlock = ({ query, queryState, setQueryState }: Props) => {
       <div onKeyDown={(e) => handleKeyDown(e)} ref={inputRef} tabIndex={0}>
         <VStack align="left">
           {queryList.map((item, i) => {
-            return <>{replaceText(i, item)}</>;
+            return <Box key={i}>{replaceText(i, item)}</Box>;
           })}
         </VStack>
       </div>


### PR DESCRIPTION
## 🔨 変更内容

- `CodeBlock`内の`map`要素にユニークな`key`を付与

## 📸 スクリーンショット

<img width="1440" alt="スクリーンショット 2023-07-02 22 57 52" src="https://github.com/nglcobdai/typing-game/assets/68684653/e6a861af-8167-4256-85b6-4faaae410480">

## ✅ 解決するイシュー

- close #20 
